### PR TITLE
Fixing pdftmp dir bug

### DIFF
--- a/pdfmaker.rb
+++ b/pdfmaker.rb
@@ -64,11 +64,12 @@ DocRaptor.api_key "#{docraptor_key}"
 testing_value = "false"
 if File.file?("#{Bkmkr::Dir.resource_dir}/staging.txt") then testing_value = "true" end
 
+`mkdir #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
+
 #if any images are in 'done' dir, grayscale and upload them to macmillan.tools site
 images = Dir.entries("#{Bkmkr::Project.working_dir}\\done\\#{pisbn}\\images\\").select {|f| !File.directory? f}
 image_count = images.count
 if image_count > 0
-	`mkdir #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
 	`copy #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
 	pdfimages = Dir.entries("#{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\").select { |f| !File.directory? f }
 	pdfimages.each do |i|

--- a/pdfmaker.rb
+++ b/pdfmaker.rb
@@ -103,13 +103,15 @@ if image_count > 0
 			end
 		end
 	end
-	`copy #{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\css\\#{Bkmkr::Project.project_dir}\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
-	`copy #{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\images\\#{Bkmkr::Project.project_dir}\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
-	`copy #{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\scripts\\#{Bkmkr::Project.project_dir}\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
-	`#{Bkmkr::Dir.bookmaker_dir}\\bookmaker_ftpupload\\imageupload.bat #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images`
 end
 
-# Are there any custom javascripts?
+# copy assets to tmp upload dir and upload to ftp
+`copy #{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\css\\#{Bkmkr::Project.project_dir}\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
+`copy #{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\images\\#{Bkmkr::Project.project_dir}\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
+`copy #{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\scripts\\#{Bkmkr::Project.project_dir}\\* #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp\\`
+`#{Bkmkr::Dir.bookmaker_dir}\\bookmaker_ftpupload\\imageupload.bat #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images\\pdftmp #{Bkmkr::Dir.tmp_dir}\\#{Bkmkr::Project.filename}\\images`
+
+# Link to custom javascript in the html head
 if File.file?("#{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\scripts\\#{Bkmkr::Project.project_dir}\\pdf.js")
 	pdfjs = File.read("#{Bkmkr::Dir.bookmaker_dir}\\bookmaker_pdfmaker\\scripts\\#{Bkmkr::Project.project_dir}\\pdf.js")
 	jsfile = "<script src='#{ftp_dir}/pdf.js'></script>"


### PR DESCRIPTION
Creating pdftmp dir before converting images, and copying pdf assets after image conversion